### PR TITLE
[#14] Improved authentication process

### DIFF
--- a/src/auth/components.tsx
+++ b/src/auth/components.tsx
@@ -64,13 +64,18 @@ export const Auth: React.FC<AuthProps> = ({
       try {
         // Try to get user information
         const user = await userManager.getUser();
-        if (!user || user.expired) {
+
+        if (user && user.access_token && !user.expired) {
+          // User authenticated
+          // NOTE: the oidc-client-js library never returns null if the user is not authenticated
+          // Checking for existence of BOTH access_token and expired field seems OK
+          // Checking only for expired field is not enough
+          setUser(user);
+        } else {
           // User not authenticated -> trigger auth flow
           await userManager.signinRedirect({
             redirect_uri: generateRedirectUri(location.href),
           });
-        } else {
-          setUser(user);
         }
       } catch (error) {
         throwError(error as Error);


### PR DESCRIPTION
Resolves #14 

There is an error in the oidc-client-js library that caused corrupted sessions not renew properly. This is now fixed by introduction of additional checks of user session properties.