### PR TITLE
Support HTTP links in vocabulary short label resolution

### DIFF
--- a/src/vocabulary-utils/vocabularyTypes.json
+++ b/src/vocabulary-utils/vocabularyTypes.json
@@ -1,26 +1,26 @@
 [
   {
-    "regex": "^https://slovník.gov.cz/datový/([ěščřžýáíéóúůďťňa-z0-9-.]+)$",
+    "regex": "^https?://slovník.gov.cz/datový/([ěščřžýáíéóúůďťňa-z0-9-.]+)$",
     "shortName": "D-SGoV-{id}"
   },
   {
-    "regex": "^https://slovník.gov.cz/agendový/([a-z0-9-]+)$",
+    "regex": "^https?://slovník.gov.cz/agendový/([a-z0-9-]+)$",
     "shortName": "A-SGoV-{id}"
   },
   {
-    "regex": "^https://slovník.gov.cz/legislativní/sbírka/([0-9]+/[0-9]+)$",
+    "regex": "^https?://slovník.gov.cz/legislativní/sbírka/([0-9]+/[0-9]+)$",
     "shortName": "L-SGoV-{id}"
   },
   {
-    "regex": "^https://slovník.gov.cz/generický/([ěščřžýáíéóúůďťňa-z0-9-.]+$)",
+    "regex": "^https?://slovník.gov.cz/generický/([ěščřžýáíéóúůďťňa-z0-9-.]+$)",
     "shortName": "G-SGoV-{id}"
   },
   {
-    "regex": "^https://slovník.gov.cz/veřejný-sektor",
+    "regex": "^https?://slovník.gov.cz/veřejný-sektor",
     "shortName": "V-SGoV"
   },
   {
-    "regex": "^https://slovník.gov.cz/základní",
+    "regex": "^https?://slovník.gov.cz/základní",
     "shortName": "Z-SGoV"
   }
 ]

--- a/test/vocabulary-utils.ts
+++ b/test/vocabulary-utils.ts
@@ -48,4 +48,18 @@ describe("Test vocabulary utils", () => {
     );
     expect(output).toEqual(expectedOutput);
   });
+  test("HTTP links are supported", () => {
+    const inputData: {[key: string]: string} = {
+      "D-SGoV-test": "http://slovník.gov.cz/datový/test",
+      "A-SGoV-test": "http://slovník.gov.cz/agendový/test",
+      "L-SGoV-111/2009": "http://slovník.gov.cz/legislativní/sbírka/111/2009",
+      "G-SGoV-test": "http://slovník.gov.cz/generický/test",
+      "V-SGoV": "http://slovník.gov.cz/veřejný-sektor",
+      "Z-SGoV": "http://slovník.gov.cz/základní"
+    }
+    for (let key of Object.keys(inputData)) {
+      const output = getVocabularyShortLabel(inputData[key]);
+      expect(output).toEqual(`${key}`)
+    }
+  });
 });


### PR DESCRIPTION
In case the vocabulary IRI was created without HTTPS (e.g., in import or by manual editing of the IRI), vocabulary label badge is not shown even for supported GoV vocabulary IRIs. I believe this restriction to HTTPS can be relaxed to support HTTP as well.

Should fix https://github.com/kbss-cvut/termit-ui/issues/218