### PR TITLE
Improved auth forward URI encoding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendata-mvcr/assembly-line-shared",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "description": "Common front end components for Assembly Line",
   "homepage": "https://github.com/opendata-mvcr/assembly-line-shared#readme",
   "author": "KODI Team",

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -1,6 +1,21 @@
 import { getEnvInstance } from "env";
 
 /**
+ * Base64 encoding helper
+ */
+const encodeBase64 = (uri: string) => {
+  return Buffer.from(uri).toString("base64");
+};
+
+/**
+ * Forward URI encoding helper
+ */
+const encodeForwardUri = (uri: string) => {
+  // Since base64 produces equal signs on the end, it needs to be further encoded
+  return encodeURI(encodeBase64(uri));
+};
+
+/**
  * OIDC variables
  */
 export const getOidcConfig = () => {
@@ -12,7 +27,7 @@ export const getOidcConfig = () => {
   return {
     authority: COMPONENTS["al-auth-server"].url,
     client_id: ID,
-    redirect_uri: `${URL}/oidc-signin-callback.html?forward_uri=${encodeURI(
+    redirect_uri: `${URL}/oidc-signin-callback.html?forward_uri=${encodeForwardUri(
       URL
     )}`,
     silent_redirect_uri: `${URL}/oidc-silent-callback.html`,
@@ -29,9 +44,9 @@ export const getOidcConfig = () => {
  */
 export const generateRedirectUri = (forwardUri: string) => {
   const env = getEnvInstance();
-  return `${env.get("URL")}/oidc-signin-callback.html?forward_uri=${encodeURI(
-    forwardUri
-  )}`;
+  return `${env.get(
+    "URL"
+  )}/oidc-signin-callback.html?forward_uri=${encodeForwardUri(forwardUri)}`;
 };
 
 /**


### PR DESCRIPTION
Due to issues with Keycloak and its handling of URL parameters, I changed the Auth component so that it encodes the redirect URL properly using base64.

After adopting this library, changes will need to be made in all frontend apps to decode the forward URL properly. MC example is here: https://github.com/opendata-mvcr/mission-control/pull/233/files